### PR TITLE
Add support for configuring service backend

### DIFF
--- a/templates/default/jail.conf.erb
+++ b/templates/default/jail.conf.erb
@@ -90,7 +90,7 @@ action = %(<%= node['fail2ban']['action'] %>)s
 [<%= service %>]
 
 enabled = <%= param['enabled'] %>
-<% %w{ port filter logpath findtime bantime maxretry protocol banaction }.each do |key| %>
+<% %w{ port filter logpath findtime bantime maxretry protocol banaction backend }.each do |key| %>
 <% if param[key] %>
 <%=key%> = <%= param[key] %>
 <% end %>


### PR DESCRIPTION
On Fedora 23 there's no /var/log/secure, fail2ban must be configured to
read directly from journald. To do that we can just set backend =
systemd in service configuration. This change adds it to known
attributes that can be set through chef.