### PR TITLE
Default config values to avoid warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,9 @@ default['fail2ban']['loglevel'] = 3
 default['fail2ban']['socket'] = '/var/run/fail2ban/fail2ban.sock'
 default['fail2ban']['logtarget'] = '/var/log/fail2ban.log'
 default['fail2ban']['pidfile'] = '/var/run/fail2ban/fail2ban.pid'
+default['fail2ban']['syslogsocket'] = 'auto'
+default['fail2ban']['dbfile'] = '/var/lib/fail2ban/fail2ban.sqlite3'
+default['fail2ban']['dbpurgeage'] = 86_400
 
 # These values will only be printed to fail2ban.conf
 # if node['fail2ban']['logtarget'] is set to 'SYSLOG'

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -44,3 +44,22 @@ socket = <%= node['fail2ban']['socket'] %>
 # Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
 #
 pidfile = <%= node['fail2ban']['pidfile'] %>
+
+# Option: syslogsocket
+# Notes: Set the syslog socket file. Only used when logtarget is SYSLOG
+#        auto uses platform.system() to determine predefined paths
+# Values: [ auto | FILE ]  Default: auto
+syslogsocket = <%= node['fail2ban']['syslogsocket'] %>
+
+# Options: dbfile
+# Notes.: Set the file for the fail2ban persistent data to be stored.
+#         A value of ":memory:" means database is only stored in memory
+#         and data is lost when fail2ban is stopped.
+#         A value of "None" disables the database.
+# Values: [ None :memory: FILE ] Default: /var/lib/fail2ban/fail2ban.sqlite3
+dbfile = <%= node['fail2ban']['dbfile'] %>
+
+# Options: dbpurgeage
+# Notes.: Sets age at which bans should be purged from the database
+# Values: [ SECONDS ] Default: 86400 (24hours)
+dbpurgeage = <%= node['fail2ban']['dbpurgeage'] %>


### PR DESCRIPTION
At least in Fail2Ban v0.9.3 it prints some warnings on reload, because of these 3 parameters not defined in fail2ban.conf. Just added them with their default values.