### PR TITLE
fixing for ubuntu > 15.0

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -8,6 +8,7 @@ transport:
 
 provisioner:
   name: dokken
+  deprecations_as_errors: true
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  deprecations_as_errors: true
 
 platforms:
   - name: centos-6.8

--- a/README.md
+++ b/README.md
@@ -99,9 +99,13 @@ default['fail2ban']['filters'] = {
 }
 ```
 
-### Particular those related to rsyslog
+Issues related to rsyslog
+==========================
 
-If you are using rsyslog parameter "$RepeatedMsgReduction on" in rsyslog.conf file then you can get "Last message repeated N times" in system log file (for example auth.log). And it will affect the work of fail2ban, so that fail2ban will not work because the internal counter maxretry will not extend their Then you can change parameter "$RepeatedMsgReduction off" in rsyslog.conf file for maximum accuracy of maximum failed login attempts
+If you are using rsyslog parameter "$RepeatedMsgReduction on" in rsyslog.conf file
+then you can get "Last message repeated N times" in system log file (for example auth.log).
+Fail2ban will not work because the internal counter maxretry will not expand the repeated messages.
+Change parameter "$RepeatedMsgReduction off" in rsyslog.conf file for maximum accuracy of failed login attempts.
 
 This rsyslog parameter is default ON for ubuntu 12.04 LTS for example.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,4 +16,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/fail2ban'
 issues_url 'https://github.com/chef-cookbooks/fail2ban/issues'
-chef_version '>= 12.1'
+chef_version '>= 12.5'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,21 @@
 # epel repository is needed for the fail2ban package on rhel
 include_recipe 'yum-epel' if platform_family?('rhel')
 
+service 'fail2ban' do
+  supports [status: true, restart: true]
+  action :nothing
+
+  if platform?('ubuntu') && node['platform_version'].to_f >= 15.10
+    provider Chef::Provider::Service::Init::Systemd
+  end
+
+  if (platform?('ubuntu') && node['platform_version'].to_f < 12.04) ||
+     (platform?('debian') && node['platform_version'].to_f < 7)
+    # status command returns non-0 value only since fail2ban 0.8.6-3 (Debian)
+    status_command "/etc/init.d/fail2ban status | grep -q 'is running'"
+  end
+end
+
 package 'fail2ban' do
   action :install
 end
@@ -46,15 +61,4 @@ template '/etc/fail2ban/jail.local' do
   group 'root'
   mode '0644'
   notifies :restart, 'service[fail2ban]'
-end
-
-service 'fail2ban' do
-  supports [status: true, restart: true]
-  action [:enable, :start]
-
-  if (platform?('ubuntu') && node['platform_version'].to_f < 12.04) ||
-     (platform?('debian') && node['platform_version'].to_f < 7)
-    # status command returns non-0 value only since fail2ban 0.8.6-3 (Debian)
-    status_command "/etc/init.d/fail2ban status | grep -q 'is running'"
-  end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -16,11 +16,6 @@ describe 'fail2ban::default converge' do
     expect(chef_run).to install_package('fail2ban')
   end
 
-  it 'should start and enable service fail2ban' do
-    expect(chef_run).to start_service('fail2ban')
-    expect(chef_run).to enable_service('fail2ban')
-  end
-
   it 'should template fail2ban.conf' do
     expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf')
   end

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -17,7 +17,7 @@
 #          4 = DEBUG
 # Values:  NUM  Default:  3
 #
-loglevel = <%= node['fail2ban']['loglevel'] %>
+loglevel = INFO
 
 # Option:  logtarget
 # Notes.:  Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.


### PR DESCRIPTION
### Description
Add ubuntu platform guards to default recipe
Update README to be more clear with regards to rsyslog
Remove defaults-debian.conf on ubuntu platforms, that assumes ssh enabled on nodes.
Modify metadata dependency to Chef 12.5+
Reorder resources changing service action to nothing
Modify chef spec to remove service start, enable on resources as on debian platforms the service is started by install of package
Make test kitchen show deprecation errors
Remove EOL debian and ubuntu logic from default recipe
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Issues Resolved

Issue: #34 
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
