### PR TITLE
Remove defunct syslog config statements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,11 +24,6 @@ default['fail2ban']['pidfile'] = '/var/run/fail2ban/fail2ban.pid'
 default['fail2ban']['dbfile'] = '/var/lib/fail2ban/fail2ban.sqlite3'
 default['fail2ban']['dbpurgeage'] = 86_400
 
-# These values will only be printed to fail2ban.conf
-# if node['fail2ban']['logtarget'] is set to 'SYSLOG'
-default['fail2ban']['syslog_target'] = '/var/log/fail2ban.log'
-default['fail2ban']['syslog_facility'] = '1'
-
 # jail.conf configuration options
 default['fail2ban']['ignoreip'] = '127.0.0.1/8'
 default['fail2ban']['findtime'] = 600

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -25,10 +25,6 @@ loglevel = INFO
 # Values:  STDOUT STDERR SYSLOG file  Default:  /var/log/fail2ban.log
 #
 logtarget = <%= node['fail2ban']['logtarget'] %>
-<% if node['fail2ban']['logtarget'] == "SYSLOG" -%>
-syslog-target = <%= node['fail2ban']['syslog_target'] %>
-syslog-facility = <%= node['fail2ban']['syslog_facility'] %>
-<% end -%>
 
 # Option: syslogsocket
 # Notes: Set the syslog socket file. Only used when logtarget is SYSLOG


### PR DESCRIPTION
Signed-off-by: Peter Walz <pnw@umn.edu>

### Description

This PR removes the `syslog_target` and `syslog_facility` attributes, and the corresponding `syslog-target` and `syslog-facility` statements in `fail2ban.conf`. Those statements haven't been effective since fail2ban 0.6.x, which was superseded in 2007 by fail2ban 0.8.x. Through at least fail2ban 0.9.x, those statements don't cause an error in fail2ban, but they also don't serve any purpose.

### Issues Resolved

Resolves #31 and reverts #6.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>