### PR TITLE
Correctly deal with 0.10 an onwards version to avoid logspew

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,7 @@ template '/etc/fail2ban/fail2ban.conf' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables(lazy { { f2b_version: node['packages']['fail2ban']['version'].match(/^[0-9]+\.[0-9]+/)[0].to_f } })
+  variables(lazy { { f2b_version: node['packages']['fail2ban']['version'] } })
   notifies :restart, 'service[fail2ban]'
 end
 

--- a/templates/default/fail2ban.conf.erb
+++ b/templates/default/fail2ban.conf.erb
@@ -3,12 +3,17 @@
 # Fail2Ban main configuration file
 #
 # Comments: use '#' for comment lines and ';' (following a space) for inline comments
+<%
+  version_major = @f2b_version[0].to_i
+  version_minor = @f2b_version[1].to_i
+  version_patch = @f2b_version[2]
+%>
 
 [Definition]
-
+# Config for version: <%= @f2b_version %>
 # Option: loglevel
 # Notes.: Set the log level output.
-<% if @f2b_version.to_f < 0.9 -%>
+<% if version_major > 0 or (version_major == 0 and version_minor >= 9) -%>
 #         1 = ERROR
 #         2 = WARN
 #         3 = INFO
@@ -36,7 +41,7 @@ loglevel = <%= node['fail2ban']['loglevel'] %>
 # Values: [ STDOUT | STDERR | SYSLOG | FILE ]  Default: STDERR
 logtarget = <%= node['fail2ban']['logtarget'] %>
 
-<% if @f2b_version.to_f >= 0.9 -%>
+<% if version_major > 0 or (version_major == 0 and version_minor >= 9) -%>
 # Option: syslogsocket
 # Notes: Set the syslog socket file. Only used when logtarget is SYSLOG
 #        auto uses platform.system() to determine predefined paths
@@ -57,7 +62,7 @@ socket = <%= node['fail2ban']['socket'] %>
 # Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
 pidfile = <%= node['fail2ban']['pidfile'] %>
 
-<% if @f2b_version.to_f >= 0.9 -%>
+<% if version_major > 0 or (version_major == 0 and version_minor >= 9) -%>
 # Options: dbfile
 # Notes.: Set the file for the fail2ban persistent data to be stored.
 #         A value of ":memory:" means database is only stored in memory


### PR DESCRIPTION
Correctly deal with 0.10 an onwards version to avoid logspew due to numeric logging level

### Description

Correctly parse the fail2ban version number and write appropriate config entries to use INFO instead of 3 in fail2ban.conf, and avoid fail2ban parsing 3 as super-verbose, and the associated huge log file.

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
