### PR TITLE
Delete jail.d/00-firewalld.conf on CentOS like we delete jail.d/defau…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,11 @@ file '/etc/fail2ban/jail.d/defaults-debian.conf' do
   only_if { platform?('ubuntu') }
 end
 
+file '/etc/fail2ban/jail.d/00-firewalld.conf' do
+  action 'delete'
+  only_if { platform?('centos') }
+end
+
 service 'fail2ban' do
   supports [status: true, restart: true]
   action [:enable, :start] if platform_family?('rhel')


### PR DESCRIPTION
### Description

Delete jail.d/00-firewalld.conf on CentOS like we delete jail.d/defaults-debian.conf on Ubuntu

### Issues Resolved

None that I see reported.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
