### PR TITLE
Support Ubuntu 18.04 and fail2ban 0.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rspec'
+gem 'chefspec'
+gem 'berkshelf'
 gem 'community_cookbook_releaser'

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ default['fail2ban']['filters'] = {
 }
 ```
 
+## Testing
+
+To execute the unit tests:
+
+```
+bundle install
+bundle exec berks install
+bundle exec rspec spec/unit/recipes/default_spec.rb
+```
+
 Issues related to rsyslog
 ==========================
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,7 @@ template '/etc/fail2ban/fail2ban.conf' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables(lazy { { f2b_version: node['packages']['fail2ban']['version'].match(/^[0-9]+\.[0-9]+/)[0].to_f } })
+  variables(lazy { { f2b_version: node['packages']['fail2ban']['version'] } })
   notifies :restart, 'service[fail2ban]'
 end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/centos_spec.rb')
+require File.expand_path(File.dirname(__FILE__) + '/ubuntu_spec.rb')
 
 describe 'fail2ban::default converge' do
   let(:chef_run) do

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -31,3 +31,25 @@ describe 'default recipe on Ubuntu 14.04' do
     expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf').with_content(/^loglevel = 3/)
   end
 end
+
+describe 'default recipe on Ubuntu 18.04' do
+  let(:chef_run) do
+    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04')
+    runner.node.normal['packages']['fail2ban'] = { version: '0.10.2-2', arch: 'all' }
+    runner.converge('fail2ban::default')
+  end
+
+  it 'converges successfully' do
+    expect { :chef_run }.to_not raise_error
+  end
+
+  it 'should template fail2ban.conf' do
+    expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf').with_content { |content|
+      expect(content).to match(/^loglevel = INFO/)
+      expect(content).to match(/^syslogsocket = auto/)
+      expect(content).to match(/^dbfile = \/var\/lib\/fail2ban\/fail2ban.sqlite3/)
+      expect(content).to match(/^dbpurgeage = 86400/)
+    }
+  end
+end
+

--- a/spec/unit/recipes/ubuntu_spec.rb
+++ b/spec/unit/recipes/ubuntu_spec.rb
@@ -47,9 +47,8 @@ describe 'default recipe on Ubuntu 18.04' do
     expect(chef_run).to render_file('/etc/fail2ban/fail2ban.conf').with_content { |content|
       expect(content).to match(/^loglevel = INFO/)
       expect(content).to match(/^syslogsocket = auto/)
-      expect(content).to match(/^dbfile = \/var\/lib\/fail2ban\/fail2ban.sqlite3/)
+      expect(content).to match(%r{^dbfile = /var/lib/fail2ban/fail2ban.sqlite3})
       expect(content).to match(/^dbpurgeage = 86400/)
     }
   end
 end
-

--- a/templates/fail2ban.conf.erb
+++ b/templates/fail2ban.conf.erb
@@ -8,7 +8,7 @@
 
 # Option: loglevel
 # Notes.: Set the log level output.
-<% if @f2b_version.to_f < 0.9 -%>
+<% if Gem::Version.new(@f2b_version) < Gem::Version.new('0.9') -%>
 #         1 = ERROR
 #         2 = WARN
 #         3 = INFO
@@ -36,7 +36,7 @@ loglevel = <%= node['fail2ban']['loglevel'] %>
 # Values: [ STDOUT | STDERR | SYSLOG | FILE ]  Default: STDERR
 logtarget = <%= node['fail2ban']['logtarget'] %>
 
-<% if @f2b_version.to_f >= 0.9 -%>
+<% if Gem::Version.new(@f2b_version) >= Gem::Version.new('0.9') -%>
 # Option: syslogsocket
 # Notes: Set the syslog socket file. Only used when logtarget is SYSLOG
 #        auto uses platform.system() to determine predefined paths
@@ -57,7 +57,7 @@ socket = <%= node['fail2ban']['socket'] %>
 # Values: [ FILE ]  Default: /var/run/fail2ban/fail2ban.pid
 pidfile = <%= node['fail2ban']['pidfile'] %>
 
-<% if @f2b_version.to_f >= 0.9 -%>
+<% if Gem::Version.new(@f2b_version) >= Gem::Version.new('0.9') -%>
 # Options: dbfile
 # Notes.: Set the file for the fail2ban persistent data to be stored.
 #         A value of ":memory:" means database is only stored in memory


### PR DESCRIPTION
### Description

Ubuntu 18.04 provides fail2ban 0.10. The previous version string comparison performed a floating point comparison, however using this comparison erroneously yields version 0.10 < 0.9.

This change modifies the version string comparison to [use Gem::Version](https://medium.com/little-programming-joys/how-to-compare-version-strings-in-ruby-ced0916a4b71).

### Issues Resolved

None

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
